### PR TITLE
Dockerfile: Update to nvidia/cuda:11.6.2-cudnn8-devel-ubuntu20.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1.4
 ARG BASE_IMAGE=ubuntu:20.04
-ARG BASE_RUNTIME_IMAGE=nvidia/cuda:11.6.0-cudnn8-devel-ubuntu20.04
+ARG BASE_RUNTIME_IMAGE=nvidia/cuda:11.6.2-cudnn8-devel-ubuntu20.04
 
 FROM ${BASE_IMAGE} AS python-env
 


### PR DESCRIPTION
`nvidia/cuda:11.6.0-cudnn8-devel-ubuntu20.04` has been deleted by NVIDIA (probably due to security issue).