### PR TITLE
Downgrade torch to cuda 11.6

### DIFF
--- a/requirements.in
+++ b/requirements.in
@@ -1,7 +1,8 @@
+--extra-index-url https://download.pytorch.org/whl/cu116
+torch==1.13.1+cu116
+torchvision==0.14.1+cu116
+pytorch-lightning
 numpy
 scipy
-torch
-torchvision
-pytorch-lightning
 pillow
 opencv-python

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,9 @@
 #
 #    pip-compile
 #
-aiohttp==3.8.5
+--extra-index-url https://download.pytorch.org/whl/cu116
+
+aiohttp==3.8.6
     # via fsspec
 aiosignal==1.3.1
     # via aiohttp
@@ -18,12 +20,6 @@ charset-normalizer==3.3.0
     # via
     #   aiohttp
     #   requests
-cmake==3.27.6
-    # via triton
-filelock==3.12.4
-    # via
-    #   torch
-    #   triton
 frozenlist==1.4.0
     # via
     #   aiohttp
@@ -34,25 +30,15 @@ idna==3.4
     # via
     #   requests
     #   yarl
-jinja2==3.1.2
-    # via torch
 lightning-utilities==0.9.0
     # via
     #   pytorch-lightning
     #   torchmetrics
-lit==17.0.2
-    # via triton
-markupsafe==2.1.3
-    # via jinja2
-mpmath==1.3.0
-    # via sympy
 multidict==6.0.4
     # via
     #   aiohttp
     #   yarl
-networkx==3.1
-    # via torch
-numpy==1.26.0
+numpy==1.26.1
     # via
     #   -r requirements.in
     #   opencv-python
@@ -60,42 +46,17 @@ numpy==1.26.0
     #   scipy
     #   torchmetrics
     #   torchvision
-nvidia-cublas-cu11==11.10.3.66
-    # via
-    #   nvidia-cudnn-cu11
-    #   nvidia-cusolver-cu11
-    #   torch
-nvidia-cuda-cupti-cu11==11.7.101
-    # via torch
-nvidia-cuda-nvrtc-cu11==11.7.99
-    # via torch
-nvidia-cuda-runtime-cu11==11.7.99
-    # via torch
-nvidia-cudnn-cu11==8.5.0.96
-    # via torch
-nvidia-cufft-cu11==10.9.0.58
-    # via torch
-nvidia-curand-cu11==10.2.10.91
-    # via torch
-nvidia-cusolver-cu11==11.4.0.1
-    # via torch
-nvidia-cusparse-cu11==11.7.4.91
-    # via torch
-nvidia-nccl-cu11==2.14.3
-    # via torch
-nvidia-nvtx-cu11==11.7.91
-    # via torch
 opencv-python==4.8.1.78
     # via -r requirements.in
 packaging==23.2
     # via
     #   lightning-utilities
     #   pytorch-lightning
-pillow==10.0.1
+pillow==10.1.0
     # via
     #   -r requirements.in
     #   torchvision
-pytorch-lightning==2.0.9.post0
+pytorch-lightning==2.1.0
     # via -r requirements.in
 pyyaml==6.0.1
     # via pytorch-lightning
@@ -105,40 +66,25 @@ requests==2.31.0
     #   torchvision
 scipy==1.11.3
     # via -r requirements.in
-sympy==1.12
-    # via torch
-torch==2.0.1
+torch==1.13.1+cu116
     # via
     #   -r requirements.in
     #   pytorch-lightning
     #   torchmetrics
     #   torchvision
-    #   triton
 torchmetrics==1.2.0
     # via pytorch-lightning
-torchvision==0.15.2
+torchvision==0.14.1+cu116
     # via -r requirements.in
 tqdm==4.66.1
     # via pytorch-lightning
-triton==2.0.0
-    # via torch
 typing-extensions==4.8.0
     # via
     #   lightning-utilities
     #   pytorch-lightning
     #   torch
+    #   torchvision
 urllib3==2.0.7
     # via requests
-wheel==0.41.2
-    # via
-    #   nvidia-cublas-cu11
-    #   nvidia-cuda-cupti-cu11
-    #   nvidia-cuda-runtime-cu11
-    #   nvidia-curand-cu11
-    #   nvidia-cusparse-cu11
-    #   nvidia-nvtx-cu11
 yarl==1.9.2
     # via aiohttp
-
-# The following packages are considered to be unsafe in a requirements file:
-# setuptools


### PR DESCRIPTION
PyTorchのCUDAバージョンが固定されていなかったので、PyPIから最新のCUDAライブラリが落ちてきて、Dockerイメージのものと二重にCUDAが同梱されることでイメージサイズが大きくなっていました。

PyTorchをDockerイメージに合わせたCUDAバージョンに固定します。